### PR TITLE
Fixed typo in ali.sh

### DIFF
--- a/.shoosh/ali.sh
+++ b/.shoosh/ali.sh
@@ -80,5 +80,5 @@ alias full_system_backup_without_home='sudo rsync -aAXHx --info=progress2 --dele
 dummycam() { ffmpeg -re -stream_loop -1 -i "${1}" -f v4l2 -vcodec rawvideo -pix_fmt yuv420p /dev/video2; }
 alias sv='sudo vim'
 alias tunnelfast='sudo sshuttle --method=tproxy --remote=eltokhy@52.188.119.232 0.0.0.0/0 ::/0 --exclude=213.181.225.44 --exclude=52.188.119.232'
-alias fastHotspot='nmcli wlan0 wifi hotspot ifname wlp4s0 ssid GNUHostpot password 8888#8888'
+alias fastHotspot='nmcli wlan0 wifi hotspot ifname wlp4s0 ssid GNUHotspot password 8888#8888'
 alias code='codium'


### PR DESCRIPTION
Found a typo in `fastHotspot` alias in `ali.sh`.